### PR TITLE
Revert "Bump vuetify from 2.5.10 to 2.6.10"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11092,9 +11092,9 @@
       }
     },
     "vuetify": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.6.10.tgz",
-      "integrity": "sha512-fgUeRDDCwYkwu6WGEEKGe7IdfzOsXJCZGrqkn1pcS2ycuoDL8mR2/dejH5iFNnBY6MnsT365PAGn0J+9otjfQg=="
+      "version": "2.5.10",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.5.10.tgz",
+      "integrity": "sha512-UODZQrib36l7i1WGg0MUvurczLspYTe0nKAmfbwyMs6dC2lG1Q1VV9caqPbCAB9zgG6QIJaOmRQKSKduw9eZTw=="
     },
     "vuex": {
       "version": "3.6.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "vue-js-modal": "^2.0.0-rc.6",
     "vue-router": "^3.4.3",
     "vue-typer": "^1.2.0",
-    "vuetify": "^2.6.10",
+    "vuetify": "^2.3.10",
     "vuex": "^3.5.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Reverts infosec-ucalgary/website-frontend#136

The version of nodejs is stuck at 13.4.0 currently. reverting vuetify to a point so the page can still be built.